### PR TITLE
Fix extra delete call

### DIFF
--- a/src/S3Store.php
+++ b/src/S3Store.php
@@ -160,8 +160,6 @@ class S3Store implements Store
         if ($this->files->exists($file = $this->path($key))) {
             return $this->files->delete($file);
         }
-		
-		if($this->files->delete())
 
         return false;
     }


### PR DESCRIPTION
This line doesnt do anything that the previous block its already doing and its causing an exception.
```
  ArgumentCountError 

  Too few arguments to function Illuminate\Filesystem\FilesystemAdapter::delete(), 0 passed in /app/vendor/imannms/laravel-s3-cache-driver/src/S3Store.php on line 164 and exactly 1 expected

  at vendor/laravel/framework/src/Illuminate/Filesystem/FilesystemAdapter.php:343

```